### PR TITLE
Event-driven handling of field change (field to Unity).

### DIFF
--- a/Assets/Scripts/UnityInterface/MaterialSync.cs
+++ b/Assets/Scripts/UnityInterface/MaterialSync.cs
@@ -8,17 +8,17 @@ public class MaterialSync : MonoBehaviour
     {
         meshRenderer = GetComponent<MeshRenderer>();
 
-        obj.BeforeSync += OnBeforeSync;
-        obj.AfterSync += OnAfterSync;
+        obj.RegisterFieldUpdateHandler("color", () => ApplyFieldValues(obj));
+        obj.RegisterFieldUpdateHandler("alpha", () => ApplyFieldValues(obj));
 
-        ApplyState(obj);
+        ApplyFieldValues(obj);
     }
 
-    void ApplyState(SyncObject obj)
+    void ApplyFieldValues(SyncObject obj)
     {
         var color = new Color(0.0f, 0.0f, 0.0f, 1.0f);
         
-        if (obj.HasField("color") && obj.GetField("color") is Vec colorVec)
+        if (obj.TryGetField("color", out Vec colorVec))
         {
             color.r = colorVec.X;
             color.g = colorVec.Y;
@@ -26,26 +26,11 @@ public class MaterialSync : MonoBehaviour
         }
 
         // TODO: currently alpha does not work
-        if (obj.HasField("alpha") && obj.GetField("alpha") is Primitive<float> alpha)
+        if (obj.TryGetFieldPrimitive("alpha", out float alpha))
         {
-            color.a = alpha.Value;
+            color.a = alpha;
         }
 
         meshRenderer.material.color = color;
-    }
-
-    public void OnBeforeSync(SyncObject obj)
-    {
-        Color color = meshRenderer.material.color;
-
-        obj.SetField("color", new Vec(color.r, color.g, color.b));
-        obj.SetField("alpha", new Primitive<float>(color.a));
-    }
-
-    public void OnAfterSync(SyncObject obj)
-    {
-        if (GetComponent<ObjectSync>().IsOriginal) return;
-
-        ApplyState(obj);
     }
 }

--- a/Assets/Scripts/UnityInterface/ModelSync.cs
+++ b/Assets/Scripts/UnityInterface/ModelSync.cs
@@ -12,6 +12,7 @@ public class ModelSync : MonoBehaviour
 
     public async void Initialize(SyncObject obj)
     {
+        // TODO: dynamic model change handling
         if (!obj.HasField("model") || !(obj.GetField("model") is BlobHandle))
         {
             // TODO:

--- a/Assets/Scripts/UnityInterface/RigidbodySync.cs
+++ b/Assets/Scripts/UnityInterface/RigidbodySync.cs
@@ -9,6 +9,11 @@ public class RigidbodySync : MonoBehaviour
         var rb = gameObject.AddComponent<Rigidbody>();
         obj.BeforeSync += OnBeforeSync;
         obj.AfterSync += OnAfterSync;
+        obj.RegisterFieldUpdateHandler("mass", () => {
+            if (obj.TryGetFieldPrimitive("mass", out float mass))
+                rb.mass = mass;
+        });
+
         ApplyState(obj);
     }
 
@@ -20,8 +25,6 @@ public class RigidbodySync : MonoBehaviour
             rb.velocity = UnityUtil.FromVec(velocity);
         if (obj.HasField("angularVelocity") && obj.GetField("angularVelocity") is Vec angularVelocity)
             rb.angularVelocity = UnityUtil.FromVec(angularVelocity);
-        if (obj.HasField("mass") && obj.GetField("mass") is Primitive<float> massValue)
-            rb.mass = massValue.Value;
     }
 
     void OnBeforeSync(SyncObject obj)


### PR DESCRIPTION
Added `RegisterFieldUpdateHandler(string, Action)` to SyncObject and some tags are moved to this way.
This does not greatly affect behavior now, but may be useful for performance (less access to Unity property).

Also, some unused Unity-to-field parameter conversion was removed.